### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/68826c10-de32-4d34-8bf2-c56fc51d1370/b686b28f-1f55-403c-9edf-79eb094d8db5/_apis/work/boardbadge/feb8433e-744e-43e7-8bf2-2263b172c95b)](https://dev.azure.com/aiw-devops/68826c10-de32-4d34-8bf2-c56fc51d1370/_boards/board/t/b686b28f-1f55-403c-9edf-79eb094d8db5/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#341](https://dev.azure.com/aiw-devops/68826c10-de32-4d34-8bf2-c56fc51d1370/_workitems/edit/341). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.